### PR TITLE
fixed executable not running in different directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ add_executable(ogt
     ${CMAKE_SOURCE_DIR}/src/shader/shader.cpp
     ${CMAKE_SOURCE_DIR}/src/model/mesh.cpp
     ${CMAKE_SOURCE_DIR}/src/model/model.cpp
+    ${CMAKE_SOURCE_DIR}/src/utils/fileio.cpp
 )
 target_include_directories(ogt PRIVATE
     ${CMAKE_SOURCE_DIR}/external/glad/include

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -123,7 +123,7 @@ int main()
     glBufferData(GL_ARRAY_BUFFER, sizeof(vertices), vertices, GL_STATIC_DRAW);
 
     // Shader triangleShader("shaders/triangle.vert.glsl", "shaders/triangle.frag.glsl");
-    Shader triangleShader(fileio_getpath_r("shaders/triangle.vert.glsl").c_str(), fileio_getpath_r("shaders/triangle.frag.glsl").c_str());
+    Shader triangleShader(fileio_getpath("shaders/triangle.vert.glsl").c_str(), fileio_getpath("shaders/triangle.frag.glsl").c_str());
 
     unsigned int VAO;
     glGenVertexArrays(1, &VAO);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,6 +13,8 @@
 #include "model/model.h"
 #include "shader/shader.hpp"
 
+#include "utils/fileio.hpp"
+
 #include <iostream>
 
 const unsigned int SCR_WIDTH = 800;
@@ -120,7 +122,8 @@ int main()
     glBindBuffer(GL_ARRAY_BUFFER, VBO);
     glBufferData(GL_ARRAY_BUFFER, sizeof(vertices), vertices, GL_STATIC_DRAW);
 
-    Shader triangleShader("shaders/triangle.vert.glsl", "shaders/triangle.frag.glsl");
+    // Shader triangleShader("shaders/triangle.vert.glsl", "shaders/triangle.frag.glsl");
+    Shader triangleShader(fileio_getpath_r("shaders/triangle.vert.glsl").c_str(), fileio_getpath_r("shaders/triangle.frag.glsl").c_str());
 
     unsigned int VAO;
     glGenVertexArrays(1, &VAO);

--- a/src/utils/fileio.cpp
+++ b/src/utils/fileio.cpp
@@ -1,0 +1,49 @@
+#include "fileio.hpp"
+
+std::string
+fileio_getpath_r(const std::string& f, size_t md)
+{
+    namespace fs = std::filesystem;
+
+    std::function<std::string(const fs::path&, const std::string&, size_t)> search_in_dir_tree; /* forward declaration for recursion */
+    search_in_dir_tree =
+        [&search_in_dir_tree](const fs::path& dir, const std::string& filename, size_t max_depth) -> std::string {
+        try {
+            fs::path full_path = dir / filename;
+            if (fs::exists(full_path) && fs::is_regular_file(full_path))
+                return full_path.string();
+
+            if (max_depth == 0)
+                return "";
+
+            for (const auto& entry : fs::directory_iterator(dir)) {
+                if (fs::is_directory(entry)) {
+                    std::string result = search_in_dir_tree(entry.path(), filename, max_depth - 1);
+                    if (!result.empty())
+                        return result;
+                }
+            }
+        } catch (const fs::filesystem_error& e) {
+            std::cerr << e.what() << std::endl;
+        }
+        return "";
+    };
+
+    fs::path base_dir = fs::current_path();
+    for (size_t depth = 0; depth <= md; ++depth) {
+        std::string result = search_in_dir_tree(base_dir, f, md);
+        if (!result.empty())
+            return result;
+
+        if (depth == md)
+            break;
+
+        fs::path parent_dir = base_dir.parent_path();
+        if (parent_dir == base_dir)
+            break;
+
+        base_dir = parent_dir;
+    }
+
+    return "";
+}

--- a/src/utils/fileio.cpp
+++ b/src/utils/fileio.cpp
@@ -2,7 +2,9 @@
 
 namespace fs = std::filesystem;
 
-static std::string search_in_dir_tree(const fs::path& dir, const std::string& file_name, size_t max_depth)
+static std::string
+search_in_dir_tree(const fs::path& dir, const std::string& file_name,
+    size_t max_depth)
 {
     try {
         fs::path full_path = dir / file_name;
@@ -14,7 +16,8 @@ static std::string search_in_dir_tree(const fs::path& dir, const std::string& fi
 
         for (const auto& entry : fs::directory_iterator(dir)) {
             if (fs::is_directory(entry)) {
-                std::string result = search_in_dir_tree(entry.path(), file_name, max_depth - 1);
+                std::string result = search_in_dir_tree(
+                    entry.path(), file_name, max_depth - 1);
                 if (!result.empty())
                     return result;
             }
@@ -31,8 +34,11 @@ fileio_getpath(const std::string& file_path, size_t max_depth)
     fs::path base_dir = fs::current_path();
     for (size_t depth = 0; depth <= max_depth; ++depth) {
         std::string result = search_in_dir_tree(base_dir, file_path, max_depth);
-        if (!result.empty() || depth == max_depth)
+        if (!result.empty())
             return result;
+
+        if (depth == max_depth)
+            break;
 
         fs::path parent_dir = base_dir.parent_path();
         if (parent_dir == base_dir)

--- a/src/utils/fileio.cpp
+++ b/src/utils/fileio.cpp
@@ -1,42 +1,38 @@
 #include "fileio.hpp"
 
-std::string
-fileio_getpath_r(const std::string& f, size_t md)
+namespace fs = std::filesystem;
+
+static std::string search_in_dir_tree(const fs::path& dir, const std::string& file_name, size_t max_depth)
 {
-    namespace fs = std::filesystem;
+    try {
+        fs::path full_path = dir / file_name;
+        if (fs::is_regular_file(full_path))
+            return full_path.string();
 
-    std::function<std::string(const fs::path&, const std::string&, size_t)> search_in_dir_tree; /* forward declaration for recursion */
-    search_in_dir_tree =
-        [&search_in_dir_tree](const fs::path& dir, const std::string& filename, size_t max_depth) -> std::string {
-        try {
-            fs::path full_path = dir / filename;
-            if (fs::exists(full_path) && fs::is_regular_file(full_path))
-                return full_path.string();
+        if (max_depth == 0)
+            return "";
 
-            if (max_depth == 0)
-                return "";
-
-            for (const auto& entry : fs::directory_iterator(dir)) {
-                if (fs::is_directory(entry)) {
-                    std::string result = search_in_dir_tree(entry.path(), filename, max_depth - 1);
-                    if (!result.empty())
-                        return result;
-                }
+        for (const auto& entry : fs::directory_iterator(dir)) {
+            if (fs::is_directory(entry)) {
+                std::string result = search_in_dir_tree(entry.path(), file_name, max_depth - 1);
+                if (!result.empty())
+                    return result;
             }
-        } catch (const fs::filesystem_error& e) {
-            std::cerr << e.what() << std::endl;
         }
-        return "";
-    };
+    } catch (const fs::filesystem_error& e) {
+        std::cerr << e.what() << std::endl;
+    }
+    return "";
+}
 
+std::string
+fileio_getpath(const std::string& file_path, size_t max_depth)
+{
     fs::path base_dir = fs::current_path();
-    for (size_t depth = 0; depth <= md; ++depth) {
-        std::string result = search_in_dir_tree(base_dir, f, md);
-        if (!result.empty())
+    for (size_t depth = 0; depth <= max_depth; ++depth) {
+        std::string result = search_in_dir_tree(base_dir, file_path, max_depth);
+        if (!result.empty() || depth == max_depth)
             return result;
-
-        if (depth == md)
-            break;
 
         fs::path parent_dir = base_dir.parent_path();
         if (parent_dir == base_dir)

--- a/src/utils/fileio.hpp
+++ b/src/utils/fileio.hpp
@@ -2,7 +2,6 @@
 #define FILEIO_H
 
 #include <filesystem>
-#include <fstream>
 #include <iostream>
 #include <string>
 

--- a/src/utils/fileio.hpp
+++ b/src/utils/fileio.hpp
@@ -1,0 +1,22 @@
+#if !defined(FILEIO_H)
+#define FILEIO_H
+
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+
+/**
+ * Get path of given file by traversing each directory in
+ * the current directory and outer directories upto _MaxDepth levels
+ *
+ * @param _FileName name of file (can have partial path, like
+ * "shaders/some.cool.shader.glsl")
+ * @param _MaxDepth Number of directories to traverse up.
+ * A _MaxDepth of 1 means the function will search current directory (and any
+ * sub directories) and parent directory
+ */
+std::string fileio_getpath_r (const std::string &_FileName,
+                              size_t _MaxDepth = 5);
+
+#endif // FILEIO_H

--- a/src/utils/fileio.hpp
+++ b/src/utils/fileio.hpp
@@ -7,16 +7,19 @@
 #include <string>
 
 /**
- * Get path of given file by traversing each directory in
- * the current directory and outer directories upto _MaxDepth levels
+ * @brief Retrieves the absolute path of a specified file by recursively searching
+ * through the current directory and its parent directories.
  *
- * @param _FileName name of file (can have partial path, like
- * "shaders/some.cool.shader.glsl")
- * @param _MaxDepth Number of directories to traverse up.
- * A _MaxDepth of 1 means the function will search current directory (and any
- * sub directories) and parent directory
+ * @param file_name The name of the file to locate. May include a partial path
+ *                  (e.g., "shaders/some.cool.shader.glsl").
+ * @param max_depth The maximum number of parent directories to traverse upward.
+ *                  Default is 5. A value of 1 limits the search to the current
+ *                  directory, its subdirectories, and the immediate parent directory.
+ *
+ * @return std::string The absolute path to the file if found, or an empty string
+ *                     if the file cannot be located within the specified depth.
  */
-std::string fileio_getpath_r (const std::string &_FileName,
-                              size_t _MaxDepth = 5);
+std::string fileio_getpath(const std::string& file_name,
+    size_t max_depth = 5);
 
 #endif // FILEIO_H


### PR DESCRIPTION
The built executable wasn’t running within the build directory because it referenced the shaders directory, which is located in the parent directory of the build directory (OpenGL-template/build and OpenGL/template/ respectively).

To address this issue, I added `utils/fileio.hpp` and `utils/fileio.cpp`, which enable recursive path checking with a specified depth. This will be helpful as paths won’t need to be explicitly specified, and the desired file can be located “around” the executable.