### PR TITLE
Add Support for Geometry & Compute Shaders (A - Restrict filenames and detect shaders)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -126,7 +126,7 @@ int main()
     glBufferData(GL_ARRAY_BUFFER, sizeof(vertices), vertices, GL_STATIC_DRAW);
 
     // Shader triangleShader("shaders/triangle.vert.glsl", "shaders/triangle.frag.glsl");
-    Shader triangleShader(fileio_getpath("shaders/triangle.vert.glsl").c_str(), fileio_getpath("shaders/triangle.frag.glsl").c_str());
+    Shader triangleShader({ fileio_getpath("shaders/triangle.vert.glsl").c_str(), fileio_getpath("shaders/triangle.frag.glsl").c_str() });
 
     unsigned int VAO;
     glGenVertexArrays(1, &VAO);

--- a/src/shader/shader.hpp
+++ b/src/shader/shader.hpp
@@ -10,15 +10,16 @@
 
 class Shader {
 private:
-    std::string vertexPath;
-    std::string fragmentPath;
+    std::vector<std::string> loadedPaths; // paths of shaders
+
     std::unique_ptr<filewatch::FileWatch<std::string>> watcher = NULL;
     std::atomic<bool> reloadRequested = false;
 
 public:
-    unsigned int ID;
+    unsigned int ID = 0;
 
-    Shader(std::string vertexPath, std::string fragmentPath, bool enableAutoReload = true);
+    explicit Shader(const std::vector<std::string>& shaderPaths, bool enableAutoReload = true);
+    ~Shader();
 
     void use();
 


### PR DESCRIPTION
# Add Geometry & Compute Shader Support
Closes #13 

Adding Support for Geometry & Compute Shaders via overloading Shader class constructors(B) -> #16 

<details>
<summary><strong>Summary</strong></summary>

- Implements a unified shader class that detects shader stages based on file extensions.  
- Adds support for geometry shader and compute shader stages.    
- Provides example implementations demonstrating geometry shader usage for beginner and model scenarios.
- Establishes foundational compute shader examples for future expansion.  

</details>

<details>
<summary><strong>Tasks Completed</strong></summary>

### Shader System Enhancements
- [x] Implement unified, stage-agnostic shader loader  
- [x] Introduce extension-based stage detection (`.vert`, `.frag`, `.geom`, `.comp`)  

### Geometry Shader Examples
- [ ] Add beginner triangle geometry shader demonstration  
- [ ] Add triangle subdivision example (4-triangle expansion)  
- [ ] Implement normal-visualization geometry shader for model rendering  

### Compute Shader Examples
- [ ] Add compute shader demonstration for beginner triangle  
- [ ] Add utility compute shader example (texture or SSBO generation)  

</details>

<details>
<summary><strong>Usage</strong></summary>

```cpp
// Geometry shader example
Shader shader({
    "triangle.vert",
    "triangle_subdivide.geom",
    "triangle.frag"
});

// Compute shader example
Shader compute({
    "compute.comp"
});
```

</details>